### PR TITLE
CJS module

### DIFF
--- a/cmd/build_js/main.go
+++ b/cmd/build_js/main.go
@@ -67,8 +67,6 @@ var buildOptionsNode = api.BuildOptions{
 	// MinifySyntax:      true,
 	// Target: api.ES5,
 	Engines: []api.Engine{
-		{Name: api.EngineNode, Version: "16"},
-		{Name: api.EngineNode, Version: "18"},
 		{Name: api.EngineNode, Version: "20"},
 	},
 	Write: true,

--- a/cmd/build_js/main.go
+++ b/cmd/build_js/main.go
@@ -61,17 +61,10 @@ var buildOptionsNode = api.BuildOptions{
 	Loader: map[string]api.Loader{
 		".wasm": api.LoaderFile,
 	},
-	// External:          []string{"pbc.wasm"},
-	// MinifyWhitespace:  true,
-	// MinifyIdentifiers: true,
-	// MinifySyntax:      true,
-	// Target: api.ES5,
 	Engines: []api.Engine{
 		{Name: api.EngineNode, Version: "20"},
 	},
 	Write: true,
-	// Metafile:  true,
-	// Sourcemap: api.SourceMapLinked,
 }
 
 var serveOptions = api.ServeOptions{

--- a/cmd/build_js/main.go
+++ b/cmd/build_js/main.go
@@ -48,6 +48,34 @@ var buildOptions = api.BuildOptions{
 	Sourcemap: api.SourceMapLinked,
 }
 
+var buildOptionsNode = api.BuildOptions{
+	LogLevel:    api.LogLevelInfo,
+	EntryPoints: []string{"ts/index.ts"},
+	Bundle:      true,
+	Outdir:      "dist",
+	Format:      api.FormatCommonJS,
+	OutExtension: map[string]string{
+		".js": ".cjs",
+	},
+	AssetNames: "[name]",
+	Loader: map[string]api.Loader{
+		".wasm": api.LoaderFile,
+	},
+	// External:          []string{"pbc.wasm"},
+	// MinifyWhitespace:  true,
+	// MinifyIdentifiers: true,
+	// MinifySyntax:      true,
+	// Target: api.ES5,
+	Engines: []api.Engine{
+		{Name: api.EngineNode, Version: "16"},
+		{Name: api.EngineNode, Version: "18"},
+		{Name: api.EngineNode, Version: "20"},
+	},
+	Write: true,
+	// Metafile:  true,
+	// Sourcemap: api.SourceMapLinked,
+}
+
 var serveOptions = api.ServeOptions{
 	Host:     "localhost",
 	Servedir: "dist",
@@ -129,7 +157,13 @@ func main() {
 			log.Fatal(err)
 		}
 	} else {
-		result, err := build(ctx, buildOptions)
+		result, err := build(ctx, buildOptionsNode)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s", api.AnalyzeMetafile(result.Metafile, api.AnalyzeMetafileOptions{Verbose: true}))
+
+		result, err = build(ctx, buildOptions)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "types": "dist/ts/index.d.ts",
   "exports": {
     ".": {
+      "require": "./dist/index.cjs",
       "module": "./dist/index.mjs",
       "types": "./dist/ts/index.d.ts"
     },


### PR DESCRIPTION
We current build ESM modules for index and worker but it's a bit challenging to get it working for nodejs so I'm also adding a CJS build that will allow wider adoption.

It's done with separate esbuild configuration.

Building only `index.ts` entry point as worker isn't needed for node.