### PR TITLE
feat: remove message callback error return value

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -161,7 +161,7 @@ func msgGoToJs(data any) (map[string]any, error) {
 	return r, nil
 }
 
-func onMessage(msg posbus.Message) error {
+func onMessage(msg posbus.Message) {
 	// workaround: process in goroutine to avoid locking event thread
 	go func() {
 		r, err := msgGoToJs_json(msg)
@@ -177,8 +177,6 @@ func onMessage(msg posbus.Message) error {
 		}
 		msgPort.Call("postMessage", []any{typeName, r})
 	}()
-
-	return nil
 }
 
 func SetPort(this js.Value, args []js.Value) any {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -101,15 +101,14 @@ func (s *ClientTestSuite) TestClient() {
 	// channel to read back messages for testing
 	ch := make(chan any, 1)
 	s.T().Cleanup(func() {
-		client.SetCallback(func(msg posbus.Message) error {
-			return nil
+		client.SetCallback(func(msg posbus.Message) {
+			return
 		})
 		client.Close()
 		close(ch)
 	})
-	client.SetCallback(func(msg posbus.Message) error {
+	client.SetCallback(func(msg posbus.Message) {
 		ch <- msg
-		return nil
 	})
 
 	url := s.ctURL.JoinPath("posbus").String()

--- a/test/scenarios/user_flyer.go
+++ b/test/scenarios/user_flyer.go
@@ -72,15 +72,14 @@ type scenario struct {
 	rnd      *rand.Rand
 }
 
-func (s *scenario) onMessage(msg posbus.Message) error {
+func (s *scenario) onMessage(msg posbus.Message) {
 	switch m := msg.(type) {
 	case *posbus.MyTransform:
 		s.position = m.Position
 		s.rotation = m.Rotation
 		s.moving = true
-		return nil
 	default:
-		return nil
+		return
 	}
 }
 


### PR DESCRIPTION
Change the signature of the message callback function and remove the required return value.

This is a go-ism and makes it harder to use by other language clients. Since the error will be generated from native code to then be converted to golang and then back to native code.
So callbacks should not return errors (and not throw errors), but gracefully handle errors inside the callback functions themselves.