### PR TITLE
feat(pbclient): rename load function, callbacks on stop/error

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ async function main(userId: string, token: string) {
     // handle incoming messages
   });
 
-  await client.load(wasmPBC);
+  await client.loadAndStartMainLoop(wasmPBC);
 
   await client.connect(POSBUS_URL, token, userId);
 

--- a/example/nodejs/index.js
+++ b/example/nodejs/index.js
@@ -19,15 +19,29 @@ async function main(userId, token) {
     console.log(`PosBus message [${userId}]:`, event.data);
   });
 
-  await client.load(wasmPBC);
+  const doConnect = async () => {
+    await client.loadAndStartMainLoop(
+      wasmPBC,
+      () => {
+        console.log("POSBUS exit. Reconnecting in a few moments...");
+        setTimeout(() => {
+          console.log("POSBUS reconnecting...");
+          doConnect();
+        }, 2000);
+      },
+      (err) => {
+        console.error("POSBUS error:", err);
+      }
+    );
+    console.log(`PosBus client loaded [${userId}]`, client);
+    // await client.connect(`https://dev.odyssey.ninja/posbus`, token, userId);
+    await client.connect(`http://localhost:4000/posbus`, token, userId);
 
-  console.log(`PosBus client loaded [${userId}]`, client);
-  await client.connect(`https://dev.odyssey.ninja/posbus`, token, userId);
-  // await client.connect(`http://localhost:4000/posbus`, token, userId);
-
-  await sleep(500);
-  console.log(`PosBus client teleport [${userId}]`);
-  await client.teleport("00000000-0000-8000-8000-000000000005");
+    await sleep(500);
+    console.log(`PosBus client teleport [${userId}]`);
+    await client.teleport("00000000-0000-8000-8000-000000000005");
+  };
+  await doConnect();
 
   await sleep(3000);
 

--- a/ts/pbclient.ts
+++ b/ts/pbclient.ts
@@ -23,14 +23,20 @@ export class PBClient {
     this.onMessageCallback = onMessage;
   }
 
-  async load(buffer?: ArrayBuffer) {
+  async loadAndStartMainLoop(
+    buffer?: ArrayBuffer,
+    onStop?: () => void,
+    onError?: (err: Error) => void
+  ) {
     const { go, instance } = await this.loadWasm(buffer);
     go.run(instance)
       .then(() => {
         console.info("go stopped");
+        onStop?.();
       })
       .catch((err) => {
         console.error("go run", err);
+        onError?.(err);
       });
     // need delay?
     if (typeof PBC === "undefined") {


### PR DESCRIPTION
Right now we run GO client main loop without blocking on it - the disadvantage of this approach is inability to react when something happens and the client stops.

I renamed **load** -> **loadAndStartMainLoop** function and also added 2 optional callbacks for it - `onStop` and `onError`. Not perfect solution, especially considering that it's async function but at least allows reacting on these situation and reconnect.

Most common case of this sudden stop is connecting several clients (UI and bot or several bots) with same user.